### PR TITLE
Allow the root directory of the repository to be specified in config

### DIFF
--- a/DataCollector/GitDataCollector.php
+++ b/DataCollector/GitDataCollector.php
@@ -15,10 +15,12 @@ class GitDataCollector extends DataCollector
 
 	/**
 	 * @param $repositoryCommitUrl
+	 * @param $rootDir
 	 */
-	public function __construct($repositoryCommitUrl)
+	public function __construct($repositoryCommitUrl, $rootDir)
 	{
 		$this->data['repositoryCommitUrl'] = $repositoryCommitUrl;
+		$this->data['rootDir'] = $rootDir;
 	}
 
 	/**
@@ -33,9 +35,10 @@ class GitDataCollector extends DataCollector
 
 		$fs = new Filesystem();
 
-		// is there a web directory ?
-
-		if ($fs->exists('../web')) {
+		// Use the root directory config if one is provided, otherwise, attempt to automatically detect the directory.
+		if ($this->data['rootDir']) {
+			$gitPath = $this->data['rootDir'];
+		} elseif ($fs->exists('../web')) {
 			$gitPath = '../.git';
 		} else {
 			// unit tests

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -21,8 +21,8 @@ class Configuration implements ConfigurationInterface
 
 		$rootNode
 			->children()
-			->scalarNode('repository_commit_url')
-			->end()
+			->scalarNode('repository_commit_url')->end()
+			->scalarNode('root_dir')->defaultValue(null)->end()
 		;
 
 		return $treeBuilder;

--- a/DependencyInjection/SymfonyDebugToolbarGitExtension.php
+++ b/DependencyInjection/SymfonyDebugToolbarGitExtension.php
@@ -25,5 +25,6 @@ class SymfonyDebugToolbarGitExtension extends Extension
 		$loader->load('container.yml');
 
 		$container->setParameter('symfony_debug_toolbar_git.repository_commit_url', $config['repository_commit_url']);
+		$container->setParameter('symfony_debug_toolbar_git.root_dir', $config['root_dir']);
 	}
 }

--- a/Resources/config/container.yml
+++ b/Resources/config/container.yml
@@ -4,6 +4,8 @@ parameters:
 services:
     data_collector.datacollector_git:
         class: Kendrick\SymfonyDebugToolbarGit\DataCollector\GitDataCollector
-        arguments: ["%symfony_debug_toolbar_git.repository_commit_url%"]
+        arguments:
+          - "%symfony_debug_toolbar_git.repository_commit_url%"
+          - "%symfony_debug_toolbar_git.root_dir%"
         tags:
           - { name: data_collector, template: "%symfony_debug_toolbar_git.data_collector.template%", id: "datacollector_git" }


### PR DESCRIPTION
This allows users with a non-standard directory structure to manually specify the directory where the git repository resides.

If `root_dir` isn't specified, the existing behaviour will be used, maintaining backwards compatibility.