### PR TITLE
Implement reset method in GitDataCollector

### DIFF
--- a/DataCollector/GitDataCollector.php
+++ b/DataCollector/GitDataCollector.php
@@ -22,6 +22,14 @@ class GitDataCollector extends DataCollector
 	}
 
 	/**
+         * {@inheritdoc}
+         */
+	public function reset()
+	{
+		$this->data = [];
+	}
+
+	/**
 	 * Collect Git data for DebugBar (branch,commit,author,email,merge,date,message)
 	 *
 	 * @param Request $request


### PR DESCRIPTION
Fixes

> User Deprecated: Implementing "**Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface**" without the "**reset()**" method is deprecated since version 3.4 and will be unsupported in 4.0 for class "**Kendrick\SymfonyDebugToolbarGit\DataCollector\GitDataCollector**".
