### PR TITLE
to use alternative web, public_html, public

### DIFF
--- a/DataCollector/GitDataCollector.php
+++ b/DataCollector/GitDataCollector.php
@@ -43,7 +43,7 @@ class GitDataCollector extends DataCollector
 
 		// is there a web directory ?
 
-		if ($fs->exists('../web')) {
+		if ($fs->exists('../web') || $fs->exists('../public_html') || $fs->exists('../public')) {
 			$gitPath = '../.git';
 		} else {
 			// unit tests

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "kendrick/symfony-debug-toolbar-git",
+  "name": "kendrick/symfony-4-debug-toolbar-git",
   "type": "symfony-bundle",
   "description": "Git information into Symfony Debug Toolbar",
   "keywords": ["symfony","debug","git"],


### PR DESCRIPTION
To check any "web" folder in Symfony. In v4.x the main folder is "public" I always rename it as "public_html" to work with shared folders